### PR TITLE
feat: config option Dir->Client Heartbeat Interval

### DIFF
--- a/templates/client.conf.j2
+++ b/templates/client.conf.j2
@@ -14,6 +14,9 @@ Client {
 {% if item.connection_from_director_to_client is defined %}
   Connection From Director To Client = {{ item.connection_from_director_to_client | ternary('Yes', 'No') }}
 {% endif %}
+{% if item.heartbeat_interval is defined %}
+  Heartbeat Interval = {{ item.heartbeat_interval }}
+{% endif %}
 {% if item.tls_enable is defined %}
   TLS Enable = {{ item.tls_enable | ternary('Yes', 'No') }}
 {% endif %}


### PR DESCRIPTION
this optional config option is required for client initiated connections, according to the Bareos doc: https://docs.bareos.org/TasksAndConcepts/NetworkSetup.html#client-initiated-connection

Refs: https://docs.bareos.org/Configuration/Director.html#config-Dir_Client_HeartbeatInterval