### PR TITLE
feat: bareos_dir plugin support, separate vars by distro

### DIFF
--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -9,7 +9,7 @@ argument_specs:
     options:
       bareos_dir_backup_configurations:
         type: "bool"
-        default: no
+        default: false
         description: "Backup the configuration files."
       bareos_dir_hostname:
         type: "str"
@@ -85,5 +85,9 @@ argument_specs:
         description: "A list of storages to configure."
       bareos_dir_install_debug_packages:
         type: "bool"
-        default: no
+        default: false
         description: "Install debug packages. This requires the debug repositories to be enabled."
+      bareos_dir_plugins:
+        type: "list"
+        default: []
+        description: "A list of Bareos Director plugins"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -228,3 +228,5 @@
           maximum_concurrent_jobs: 3
         - name: "disabled-storage"
           enabled: no
+      bareos_dir_plugins:
+        - director-python

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -75,7 +75,14 @@
           full_backup_pool: Full
           differential_backup_pool: Differential
           incremental_backup_pool: Incremental
-        - name: "disabled-jobdef"
+        - name: DefaultJob-Plugin
+          type: Backup
+          plugin_options: |+
+            "python3"
+                         ":instance=0"
+                         ":module_name=bareos-dir-class-plugins"
+                         ":testoption=testparam"
+        - name: disabled-jobdef
           enabled: no
       bareos_dir_jobs:
         - name: my_job

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,8 @@
     - role: ansible-role-bareos_dir
       bareos_dir_backup_configurations: yes
       bareos_dir_install_debug_packages: yes
+      bareos_dir_hostname: bareos-dir
+      bareos_dir_password: "MySecretPassword"
       bareos_dir_catalogs:
         - name: MyCatalog
           dbname: bareos
@@ -79,9 +81,9 @@
           type: Backup
           plugin_options: |+
             "python3"
-                         ":instance=0"
-                         ":module_name=bareos-dir-class-plugins"
-                         ":testoption=testparam"
+                                  ":instance=0"
+                                  ":module_name=bareos-dir-class-plugins"
+                                  ":testoption=testparam"
         - name: disabled-jobdef
           enabled: no
       bareos_dir_jobs:
@@ -230,3 +232,12 @@
           enabled: no
       bareos_dir_plugins:
         - director-python
+
+    - role: ansible-role-bareos_console
+      bareos_console_directors:
+        - name: bareos-dir
+          address: localhost
+          password: "MySecretPassword"
+          description: "Bareos Console credentials for local Director"
+          tls_enable: true
+          tls_verify_peer: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -233,7 +233,7 @@
       bareos_dir_plugins:
         - director-python
 
-    - role: ansible-role-bareos_console
+    - role: adfinis.bareos_console
       bareos_console_directors:
         - name: bareos-dir
           address: localhost

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,3 +16,21 @@
       register: bareos_dir_test_config
       failed_when:
         - bareos_dir_test_config.stdout_lines is search("There are configuration warnings")
+
+    - name: Test bconsole
+      ansible.builtin.command:
+        cmd: bconsole --test-config
+      register: bareos_dir_test_config
+      failed_when:
+        - bareos_dir_test_config.stdout_lines is search("There are configuration warnings") or
+          bareos_dir_test_config.stdout_lines is search("CONFIG ERROR")
+
+    - name: Check if bareos python-dir plugin is installed
+      ansible.builtin.package:
+        name:
+          - bareos-director-python-plugin
+        state: present
+      check_mode: true
+      diff: true
+      register: _result
+      failed_when: _result.changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Pinning ansible-compat version due to [bug](https://github.com/ansible-community/molecule/issues/3903)
-ansible-compat == 3.0.2
-molecule == 5.*
-molecule-plugins[docker] == 23.*
+ansible-compat == 4.*
+molecule == 6.*
+molecule-plugins == 23.*
+docker == 7.*
 ansible-lint == 6.*
 paramiko == 3.*

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,3 +11,6 @@ roles:
   # The `core_dependencies` and `postfix` roles provide mailing capabilities for the `bareos_role`: "dir".
   # - name: robertdebock.core_dependencies
   # - name: robertdebock.postfix
+
+  # use bconsole to be able to run better tests for Bareos Director
+  - name: adfinis.bareos_console

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -5,7 +5,7 @@
     that:
       - bareos_dir_backup_configurations is defined
       - bareos_dir_backup_configurations is boolean
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_hostname
   ansible.builtin.assert:
@@ -13,7 +13,7 @@
       - bareos_dir_hostname is defined
       - bareos_dir_hostname is string
       - bareos_dir_hostname != ""
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_password
   ansible.builtin.assert:
@@ -21,7 +21,7 @@
       - bareos_dir_password is defined
       - bareos_dir_password is string
       - bareos_dir_password != ""
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_queryfile
   ansible.builtin.assert:
@@ -29,14 +29,14 @@
       - bareos_dir_queryfile is defined
       - bareos_dir_queryfile is string
       - bareos_dir_queryfile != ""
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_max_concurrent_jobs
   ansible.builtin.assert:
     that:
       - bareos_dir_max_concurrent_jobs is defined
       - bareos_dir_max_concurrent_jobs is number
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_message
   ansible.builtin.assert:
@@ -44,102 +44,109 @@
       - bareos_dir_message is defined
       - bareos_dir_message is string
       - bareos_dir_message != ""
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_tls_enable
   ansible.builtin.assert:
     that:
       - bareos_dir_tls_enable is defined
       - bareos_dir_tls_enable is boolean
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_tls_verify_peer
   ansible.builtin.assert:
     that:
       - bareos_dir_tls_verify_peer is defined
       - bareos_dir_tls_verify_peer is boolean
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_catalogs
   ansible.builtin.assert:
     that:
       - bareos_dir_catalogs is defined
       - bareos_dir_catalogs is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_consoles
   ansible.builtin.assert:
     that:
       - bareos_dir_consoles is defined
       - bareos_dir_consoles is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_clients
   ansible.builtin.assert:
     that:
       - bareos_dir_clients is defined
       - bareos_dir_clients is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_filesets
   ansible.builtin.assert:
     that:
       - bareos_dir_filesets is defined
       - bareos_dir_filesets is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_jobdefs
   ansible.builtin.assert:
     that:
       - bareos_dir_jobdefs is defined
       - bareos_dir_jobdefs is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_jobs
   ansible.builtin.assert:
     that:
       - bareos_dir_jobs is defined
       - bareos_dir_jobs is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_messages
   ansible.builtin.assert:
     that:
       - bareos_dir_messages is defined
       - bareos_dir_messages is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_pools
   ansible.builtin.assert:
     that:
       - bareos_dir_pools is defined
       - bareos_dir_pools is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_profiles
   ansible.builtin.assert:
     that:
       - bareos_dir_profiles is defined
       - bareos_dir_profiles is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_schedules
   ansible.builtin.assert:
     that:
       - bareos_dir_schedules is defined
       - bareos_dir_schedules is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_storages
   ansible.builtin.assert:
     that:
       - bareos_dir_storages is defined
       - bareos_dir_storages is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test bareos_dir_install_debug_packages
   ansible.builtin.assert:
     that:
       - bareos_dir_install_debug_packages is defined
       - bareos_dir_install_debug_packages is boolean
-    quiet: yes
+    quiet: true
+
+- name: assert | Test bareos_dir_plugins
+  ansible.builtin.assert:
+    that:
+      - bareos_dir_plugins is defined
+      - bareos_dir_plugins is iterable
+    quiet: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Import assert.yml
   ansible.builtin.import_tasks:
     file: assert.yml
-  run_once: yes
+  run_once: true
   delegate_to: localhost
 
 - name: Prevent db installation (apt)
@@ -35,7 +35,7 @@
     cmd: "{{ item }}"
     creates: "/var/log/bareos/{{ item | basename }}.log"
   become_user: postgres
-  become: yes
+  become: true
   register: bareos_setup_database
   loop: "{{ bareos_dir_install_scripts }}"
   loop_control:
@@ -227,8 +227,15 @@
     - Check configuration
     - Reload bareos-dir
 
+- name: Import plugin tasklist
+  ansible.builtin.import_tasks:
+    file: plugins.yml
+  when:
+    - bareos_dir_plugins is defined
+    - bareos_dir_plugins is iterable
+
 - name: Start bareos-dir
   ansible.builtin.service:
     name: bareos-dir
     state: started
-    enabled: yes
+    enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
   with_first_found:
     - "{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml"
     - "{{ ansible_facts.os_family }}.yml"
+    - main.yml  # use main.yml if no match was found
 
 - name: Import assert.yml
   ansible.builtin.import_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 # tasks file for bareos_dir
 
+- name: Include OS-specific vars
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_facts.distribution }}_{{ ansible_facts.distribution_major_version }}.yml"
+    - "{{ ansible_facts.os_family }}.yml"
+
 - name: Import assert.yml
   ansible.builtin.import_tasks:
     file: assert.yml

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,0 +1,18 @@
+---
+
+- name: plugins | Get data
+  ansible.builtin.set_fact:
+    _plugin_data: >-
+      {{ _plugin_data + (bareos_dir_plugin_list | selectattr('name', 'equalto', item) | list) }}
+  loop: "{{ bareos_dir_plugins }}"
+  vars:
+    _plugin_data: []  # empty list to append to
+
+- name: plugins | Install Bareos plugin packages
+  ansible.builtin.package:
+    name: "{{ item.packages }}"
+    state: present
+  loop: "{{ _plugin_data }}"
+  notify:
+    - Check configuration
+    - Reload bareos-dir

--- a/templates/bareos-dir.conf.j2
+++ b/templates/bareos-dir.conf.j2
@@ -14,4 +14,8 @@ Director {
 {% if bareos_dir_tls_verify_peer %}
   TLS Verify Peer = Yes
 {% endif %}
+{% if bareos_dir_plugins is defined %}
+  Plugin Names = "{{ bareos_dir_plugin_name }}"
+  Plugin Directory = "{{ bareos_dir_plugin_dir }}"
+{% endif %}
 }

--- a/templates/job.conf.j2
+++ b/templates/job.conf.j2
@@ -45,6 +45,9 @@
 {% if item.maximum_concurrent_jobs is defined %}
   Maximum Concurrent Jobs = {{ item.maximum_concurrent_jobs }}
 {% endif %}
+{% if item.plugin_options is defined %}
+  Dir Plugin Options = {{ item.plugin_options }}
+{% endif %}
 }
 {% else %}
 # This file is not enabled.

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,0 +1,1 @@
+RedHat_7.yml

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,10 @@
+---
+
+bareos_dir_requirements:
+  - procps
+
+bareos_dir_debug_packages:
+  - bareos-dbg
+  - gdb
+
+bareos_dir_plugin_dir: "/usr/lib/bareos/plugins"

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -4,4 +4,4 @@ bareos_dir_debug_packages:
   - bareos-debuginfo
   - gdb
 
-bareos_dir_plugin_name: python
+bareos_dir_plugin_name: python3

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -1,0 +1,7 @@
+---
+
+bareos_dir_debug_packages:
+  - bareos-debuginfo
+  - gdb
+
+bareos_dir_plugin_name: python

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,7 @@
 ---
 # vars file for bareos_dir
 
-# The requirements for bareos-dir.
-_bareos_dir_requirements:
-  default: []
-  Debian:
-    - procps
-bareos_dir_requirements: "{{ _bareos_dir_requirements[ansible_os_family] | default(_bareos_dir_requirements['default']) }}"
+bareos_dir_requirements: []
 
 # The packages to install.
 bareos_dir_packages:
@@ -20,14 +15,15 @@ bareos_dir_install_scripts:
   - /usr/lib/bareos/scripts/make_bareos_tables
   - /usr/lib/bareos/scripts/grant_bareos_privileges
 
-_bareos_dir_debug_packages:
-  default:
-    - "bareos-director-debuginfo"
-    - gdb
-  Debian:
-    - "bareos-dbg"
-    - gdb
-  RedHat-7:
-    - "bareos-debuginfo"
-    - gdb
-bareos_dir_debug_packages: "{{ _bareos_dir_debug_packages[ansible_os_family ~ '-' ~ ansible_distribution_major_version] | default(_bareos_dir_debug_packages[ansible_os_family] | default(_bareos_dir_debug_packages['default'])) }}"
+
+bareos_dir_debug_packages:
+  - bareos-director-debuginfo
+  - gdb
+
+bareos_dir_plugin_name: python3
+bareos_dir_plugin_dir: "/usr/lib64/bareos/plugins"
+
+bareos_dir_plugin_list:
+  - name: python-dir
+    packages:
+      - bareos-director-python-plugin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -26,4 +26,4 @@ bareos_dir_plugin_dir: "/usr/lib64/bareos/plugins"
 bareos_dir_plugin_list:
   - name: director-python
     packages:
-      - bareos-director-python-plugin
+      - bareos-director-python3-plugin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,6 +24,6 @@ bareos_dir_plugin_name: python3
 bareos_dir_plugin_dir: "/usr/lib64/bareos/plugins"
 
 bareos_dir_plugin_list:
-  - name: python-dir
+  - name: director-python
     packages:
       - bareos-director-python-plugin


### PR DESCRIPTION
* add plugin support for Bareos Director: https://docs.bareos.org/TasksAndConcepts/Plugins.html#director-plugins
* Molecule: 
  * Add role adfinis.bareos_console to molecule, so we can interact with the Director via bconsole for better testing.
  * Test the installation of python-dir-plugin: https://docs.bareos.org/TasksAndConcepts/Plugins.html#python-dir-plugin
* Separate vars by Distro. Only Debian and RedHat_7/CentOS_7 for now. The rest follows the standard variable set from `main.yml`.