### PR TITLE
feat: Add icinga2-mon console and profile

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -24,6 +24,11 @@
             - .status
           jobacl:
             - "*all"
+        - name: icinga2-mon
+          description: "Console used by Icinga2 monitoring checks"
+          password: "MySecretPassword"
+          profile: "icinga2-mon"
+          tls_enable: no
       bareos_dir_clients:
         - name: bareos-fd
           address: 127.0.0.1
@@ -245,6 +250,29 @@
             - "*all*"
           pluginoptionsacl:
             - "*all*"
+        - name: "icinga2-mon"
+          jobacl:
+            - "*all*"
+          clientacl:
+            - "*all*"
+          storageacl:
+            - "*all*"
+          scheduleacl:
+            - "*all*"
+          poolacl:
+            - "*all*"
+          commandacl:
+            - ".api"
+            - "list"
+            - "llist"
+            - "status"
+            - "show"
+          filesetacl:
+            - "*all*"
+          catalogacl:
+            - "*all*"
+          whereacl:
+            - "*none*"
         - name: "disabled-message"
           enabled: no
       bareos_dir_schedules:


### PR DESCRIPTION
Adding console and profile to be used by icinga2 checks.
- tls_enabled has to be set to 'no' as we don't use the ssl-psk python module (maybe we can review this for prod)
- Specifying commands to list, show and status, also .api command is needed to use the console in JSON mode.