### PR TITLE
chore(ci): update fedora versions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,7 +1,4 @@
 ---
-#
-# Ansible managed
-#
 
 name: Ansible Molecule
 
@@ -43,6 +40,10 @@ jobs:
             tag: "latest"
           - image: "fedora"
             tag: "38"
+          - image: "fedora"
+            tag: "39"
+          # TODO no packages for fedora 40 yet: https://download.bareos.org/current/
+          # pipeline will fail for now. replace 38 as soon as 40 is ready and working.
           - image: "fedora"
             tag: "latest"
           - image: "opensuse"


### PR DESCRIPTION
"latest" is now fedora 40 and is not working yet, due to missing bareos packages. Fedora latest run will fail for now. Added note to remove 38 as soon as 40 is working again.

Refs: https://download.bareos.org/current/