### PR TITLE
chore: add bareos_dir_overwrite_dir_conf option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,10 @@
 # The director has these configuration parameters.
 
 # Backup the configuration files.
-bareos_dir_backup_configurations: no
+bareos_dir_backup_configurations: false
 
 # Install debug packages. This requires the debug repositories to be enabled.
-bareos_dir_install_debug_packages: no
+bareos_dir_install_debug_packages: false
 
 # The hostname of the Director.
 bareos_dir_hostname: "{{ inventory_hostname }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,3 +80,7 @@ bareos_dir_storages: []
 
 # Enable PAM authentication
 bareos_dir_pam_auth_enable: false
+
+# Overwrite Director config
+# /etc/bareos/bareos-dir.d/director/bareos-dir.conf
+bareos_dir_overwrite_dir_conf: true

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -188,7 +188,7 @@ argument_specs:
       bareos_dir_pam_auth_username:
         type: "str"
         default: "pam-adduser"
-        description: >
+        description: >-
           Technical user account for the Bareos Console connection.
           Required to be able to add the user resources in Bareos, after a successful PAM authentication.
       bareos_dir_pam_auth_password:
@@ -200,7 +200,16 @@ argument_specs:
       bareos_dir_pam_auth_tls_enable:
         type: "bool"
         default: false
-        description: >
+        description: >-
           If TLS should be used for the Bareos Console
           WebUI does not support pre-shared keys (PSK), so if this is desired,
           an actual CA and certificates need to be in place.
+      bareos_dir_overwrite_dir_conf:
+        type: "bool"
+        default: true
+        description: >-
+          This variable is used to control the behavior of applying the bareos-dir.conf template
+          in /etc/bareos/bareos-dir.d/director/bareos-dir.conf everytime.
+          The bareos_dir role is also intended to deploy the client (Filedaemon) configurations on
+          the Director. If multiple separate repositories are used then this variable can be set to false,
+          so not all repositories overwrite the "global" Director configuration.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,13 +1,13 @@
 ---
 - name: Converge
   hosts: all
-  become: yes
-  gather_facts: yes
+  become: true
+  gather_facts: true
 
   roles:
     - role: ansible-role-bareos_dir
-      bareos_dir_backup_configurations: yes
-      bareos_dir_install_debug_packages: yes
+      bareos_dir_backup_configurations: true
+      bareos_dir_install_debug_packages: false
       bareos_dir_hostname: bareos-dir
       bareos_dir_password: "MySecretPassword"
       bareos_dir_catalogs:
@@ -36,7 +36,7 @@
           password: "MySecretPassword"
           maximum_concurrent_jobs: 3
         - name: "disabled-client"
-          enabled: no
+          enabled: false
       bareos_dir_filesets:
         - name: LinuxAll
           description: "Backup all regular filesystems, determined by filesystem type."
@@ -46,7 +46,7 @@
             exclude_dirs_containing: nobackup
             options:
               signature: MD5
-              one_fs: no
+              one_fs: false
               fs_types:
                 - btrfs
                 - ext2
@@ -108,7 +108,7 @@
                            ":db_host=/run/postgresql/"
                            ":wal_archive_dir=/var/lib/pgsql/wal_archive/"
         - name: disabled-fileset
-          enabled: no
+          enabled: false
       bareos_dir_jobdefs:
         - name: DefaultJob-1
           type: Backup
@@ -131,7 +131,7 @@
                                   ":module_name=bareos-dir-class-plugins"
                                   ":testoption=testparam"
         - name: disabled-jobdef
-          enabled: no
+          enabled: false
       bareos_dir_jobs:
         - name: my_job
           description: "My backup job"
@@ -142,7 +142,7 @@
           storage: File-1
           messages: Standard
         - name: disabled_job
-          enabled: no
+          enabled: false
         - name: BackupCatalog
           description: "Backup the catalog database (after the nightly save)"
           jobdefs: DefaultJob
@@ -174,7 +174,7 @@
             - "!skipped"
             - "!saved"
         - name: "disabled-message"
-          enabled: no
+          enabled: false
         - name: Daemon
           description: "Message delivery for daemon messages (no job)."
           mailcommand: '/usr/bin/bsmtp -h localhost -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r'
@@ -210,14 +210,14 @@
       bareos_dir_pools:
         - name: Full
           pool_type: Backup
-          recycle: yes
-          autoprune: yes
+          recycle: true
+          autoprune: true
           volume_retention: 365 days
           maximum_volume_bytes: 50G
           maximum_volumes: 100
           label_format: "Full-"
         - name: "disabled-pool"
-          enabled: no
+          enabled: false
       bareos_dir_profiles:
         - name: webui-admin
           jobacl:
@@ -252,7 +252,7 @@
           pluginoptionsacl:
             - "*all*"
         - name: "disabled-message"
-          enabled: no
+          enabled: false
       bareos_dir_schedules:
         - name: WeeklyCycle
           run:
@@ -264,18 +264,18 @@
           run:
             - Full mon-fri at 21:10
         - name: "disabled-schedule"
-          enabled: no
+          enabled: false
       bareos_dir_storages:
         - name: File-1
           address: dir-1
           password: "MySecretPassword"
           device: FileStorage
           media_type: File
-          tls_enable: yes
-          tls_verify_peer: no
+          tls_enable: true
+          tls_verify_peer: false
           maximum_concurrent_jobs: 3
         - name: "disabled-storage"
-          enabled: no
+          enabled: false
       bareos_dir_plugins:
         - director-python
 

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -213,3 +213,10 @@
       - bareos_dir_plugin_list is defined
       - bareos_dir_plugin_list is iterable
     quiet: true
+
+- name: assert | bareos_dir_overwrite_dir_conf
+  ansible.builtin.assert:
+    that:
+      - bareos_dir_overwrite_dir_conf is defined
+      - bareos_dir_overwrite_dir_conf is boolean
+    quiet: true

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -214,7 +214,7 @@
       - bareos_dir_plugin_list is iterable
     quiet: true
 
-- name: assert | bareos_dir_overwrite_dir_conf
+- name: assert | Test bareos_dir_overwrite_dir_conf
   ansible.builtin.assert:
     that:
       - bareos_dir_overwrite_dir_conf is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,8 @@
     group: bareos
     mode: "0640"
     backup: "{{ bareos_dir_backup_configurations }}"
+  when:
+    - bareos_dir_overwrite_dir_conf
   notify:
     - Check configuration
     - Reload bareos-dir


### PR DESCRIPTION
This variable is used to control the behavior of applying the bareos-dir.conf template in /etc/bareos/bareos-dir.d/director/bareos-dir.conf everytime.
The bareos_dir role is also intended to deploy the client (Filedaemon) configurations on the Director. If multiple separate repositories are used then this variable can be set to false, so not all repositories overwrite the "global" Director configuration.