### PR TITLE
fix(templates): bareos-dir.conf.j2 TLS conditional

### DIFF
--- a/templates/bareos-dir.conf.j2
+++ b/templates/bareos-dir.conf.j2
@@ -11,8 +11,11 @@ Director {
 
   TLS Enable = {{ bareos_dir_tls_enable | ternary("yes","no")}}
 {% if bareos_dir_tls_ca_cert_dest is defined and
+  bareos_dir_tls_ca_cert_src != "" and
   bareos_dir_tls_cert_dest is defined and
-  bareos_dir_tls_cert_key_dest is defined
+  bareos_dir_tls_cert_src != "" and
+  bareos_dir_tls_cert_key_dest is defined and
+  bareos_dir_tls_cert_key_src != ""
 %}
   TLS CA Certificate File = {{ bareos_dir_tls_ca_cert_dest }}
   TLS Certificate = {{ bareos_dir_tls_cert_dest }}


### PR DESCRIPTION
Conditionals did not support TLS-PSK and always added the certificate parameters to bareos-dir.conf, as the variables are set in defaults/main.yml. This way TLS can be enabled without parsing certificates, which will then use TLS-PSK which is the Bareos default.